### PR TITLE
Calendar support

### DIFF
--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -30,13 +30,7 @@ Module.register('MMM-MyCommute', {
     travelTimeFormatTrim: "left",
     pollFrequency: 10 * 60 * 1000, //every ten minutes, in milliseconds
     maxCalendarEvents: 0,
-    calendarOptions: [{
-      mode: 'driving'
-    },
-    {
-      mode: 'transit',
-      transitMode: 'train'
-    }],
+    calendarOptions: [{mode: 'driving'}],
     destinations: [
       {
         destination: '40 Bay St, Toronto, ON M5J 2X2',

--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -194,7 +194,8 @@ Module.register('MMM-MyCommute', {
         this.appointmentDestinations.push.apply(this.appointmentDestinations,
           this.config.calendarOptions.map( calOpt => Object.assign({}, calOpt, {
             label: calevt.title,
-            destination: calevt.location
+            destination: calevt.location,
+            arrival_time: calevt.startDate
           }))
         );
       }
@@ -307,7 +308,11 @@ Module.register('MMM-MyCommute', {
 
     }
 
-    params += '&departure_time=now'; //needed for time based on traffic conditions
+    if (dest.arrival_time) {
+      params += '&arrival_time=' + dest.arrival_time;
+    } else {
+      params += '&departure_time=now'; //needed for time based on traffic conditions
+    }
 
     return params;
 

--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -30,6 +30,7 @@ Module.register('MMM-MyCommute', {
     travelTimeFormatTrim: "left",
     pollFrequency: 10 * 60 * 1000, //every ten minutes, in milliseconds
     maxCalendarEvents: 0,
+    maxCalendarTime: 24 * 60 * 60 * 1000,
     calendarOptions: [{mode: 'driving'}],
     destinations: [
       {
@@ -184,7 +185,12 @@ Module.register('MMM-MyCommute', {
 
     for ( var i=0; i<payload.length && this.appointmentDestinations.length<this.config.maxCalendarEvents; ++i ) {
       var calevt = payload[i];
-      if ( 'location' in calevt && calevt.location !== undefined && calevt.location !== false ) {
+      if (
+          'location' in calevt &&
+          calevt.location !== undefined &&
+          calevt.location !== false &&
+          calevt.startDate < (Date.now() + this.config.maxCalendarTime)
+      ) {
         this.appointmentDestinations.push.apply(this.appointmentDestinations,
           this.config.calendarOptions.map( calOpt => Object.assign({}, calOpt, {
             label: calevt.title,

--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -204,8 +204,6 @@ Module.register('MMM-MyCommute', {
     // Make sure appointmentDestinations is not too long
     // Which could happend because of inner forEach on calendarOptions
     this.appointmentDestinations = this.appointmentDestinations.slice(0, this.config.maxCalendarEvents);
-
-    this.getData();
   },
 
 
@@ -541,6 +539,7 @@ Module.register('MMM-MyCommute', {
       this.isHidden = true;
     } else if ( notification === 'CALENDAR_EVENTS' ) {
       this.setAppointmentDestinations(payload);
+      this.getData();
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -226,11 +226,15 @@ Additionally MMM-MyCommute can show travel times to upcoming events in the defau
   <tbody>
     <tr>
       <td><code>maxCalendarEvents</code></td>
-      <td>Number of routes to show.<br><br><strong>Type:</strong> <code>int</code><br>Defaults to `0`</td>
+      <td>Number of routes to show.<br><br><strong>Type:</strong> <code>int</code><br>Defaults to <code>0</code></td>
+    </tr>
+    <tr>
+      <td><code>maxCalendarTime</code></td>
+      <td>Show routes only for appointments within this timeframe (in milliseconds).<br><br><strong>Type:</strong> <code>int</code><br>Defaults to <code>24 * 60 * 60 * 1000</code> (1 day)</td>
     </tr>
     <tr>
       <td><code>calendarOptions</code></td>
-      <td>An array like the regular `destinations`. For each event all of these options are added as a route. All options from above can be used, except that `label` will be overwritten with the event subject and `destination` with the event location.<br><br><strong>Type:</strong> <code>array</code><br>Defaults to <code>[{mode: 'driving'}]</code></td>
+      <td>An array like the regular <code>destinations</code>. For each event all of these options are added as a route. All options from above can be used, except that <code>label</code> will be overwritten with the event subject and <code>destination</code> with the event location.<br><br><strong>Type:</strong> <code>array</code><br>Defaults to <code>[{mode: 'driving'}]</code></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -213,6 +213,58 @@ Here is an example of an entry in `config.js`
 }
 ```
 
+## Routes for calendar events
+Additionally MMM-MyCommute can show travel times to upcoming events in the default calendar module. The config can be extended with the following options. Routes will be shown for events with a location.
+
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th>Descriptio</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>maxCalendarEvents</code></td>
+      <td>Number of routes to show.<br><br><strong>Type:</strong> <code>int</code><br>Defaults to `0`</td>
+    </tr>
+    <tr>
+      <td><code>calendarOptions</code></td>
+      <td>An array like the regular `destinations`. For each event all of these options are added as a route. All options from above can be used, except that `label` will be overwritten with the event subject and `destination` with the event location.<br><br><strong>Type:</strong> <code>array</code><br>Defaults to <code>[{mode: 'driving'}]</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Here is an example of an entry in `config.js` including calendar event routes
+```
+{
+  module: 'MMM-MyCommute',
+  position: 'top_left',
+  config: {
+    apikey: 'API_KEY_FROM_GOOGLE',
+    origin: '65 Front St W, Toronto, ON M5J 1E6',
+    destinations: [
+      {
+        destination: '14 Duncan St Toronto, ON M5H 3G8',
+        label: 'Air Canada Centre',
+        mode: 'walking',
+        color: '#82E5AA'
+      }
+    ],
+    // Additional config for calendar routes:
+    maxCalendarEvents: 2,
+    calendarOptions: [
+      {
+        mode: 'driving'
+      },
+      {
+        mode: 'transit',
+        transitMode: 'train'
+      }
+    ]
+  }
+}
+```
 
 ## Dependencies
 Installed during installation
@@ -222,3 +274,4 @@ Installed during installation
 ## Special Thanks
 - [Michael Teeuw](https://github.com/MichMich) for creating the awesome [MagicMirror2](https://github.com/MichMich/MagicMirror/tree/develop) project that made this module possible.
 - [Dominic Marx](https://github.com/domsen123) for creating the original mrx-work-traffic that this module heavily borrows upon.
+- [Chris van Marle](https://github.com/qistoph) for adding calendar based routes.

--- a/node_helper.js
+++ b/node_helper.js
@@ -27,16 +27,16 @@ module.exports = NodeHelper.create({
   },
 
 
-	
-	getPredictions: function(payload) {
-		var self = this;
+
+  getPredictions: function(payload) {
+    var self = this;
 
     var returned = 0;
     var predictions = new Array();
 
-		payload.destinations.forEach(function(dest, index) {
-			request({url: dest.url, method: 'GET'}, function(error, response, body) {
-				
+    payload.destinations.forEach(function(dest, index) {
+      request({url: dest.url, method: 'GET'}, function(error, response, body) {
+
         var prediction = new Object({
           config: dest.config
         });
@@ -50,7 +50,7 @@ module.exports = NodeHelper.create({
             console.log("MMM-MyCommute: " + data.error_message);
             prediction.error = true;
           } else {
-  
+
             var routeList = new Array();
             for (var i = 0; i < data.routes.length; i++) {
               var r = data.routes[i];
@@ -83,7 +83,7 @@ module.exports = NodeHelper.create({
               routeList.push(routeObj);
             }
             prediction.routes = routeList;
-            
+
           }
 
         } else {
@@ -101,6 +101,6 @@ module.exports = NodeHelper.create({
 
       });
     });
-	}
-	
+  }
+
 });


### PR DESCRIPTION
This PR adds the option to show routes for upcoming events in the default calendar module. Routes will be shown for events with a location.

Here is an example of an entry in config.js including calendar event routes
````
{
  module: 'MMM-MyCommute',
  position: 'top_left',
  config: {
    apikey: 'API_KEY_FROM_GOOGLE',
    origin: '65 Front St W, Toronto, ON M5J 1E6',
    destinations: [
      {
        destination: '14 Duncan St Toronto, ON M5H 3G8',
        label: 'Air Canada Centre',
        mode: 'walking',
        color: '#82E5AA'
      }
    ],
    // Additional config for calendar routes:
    maxCalendarEvents: 2,
    calendarOptions: [
      {
        mode: 'driving'
      },
      {
        mode: 'transit',
        transitMode: 'train'
      }
    ]
  }
}
````