### PR TITLE
Fix formatting time diffs and remove dependency on moment-duration

### DIFF
--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -58,7 +58,7 @@ Module.register('MMM-MyCommute', {
 
   // Define required scripts.
   getScripts: function() {
-    return ["moment.js", this.file("node_modules/moment-duration-format/lib/moment-duration-format.js")];
+    return ["moment.js"];
   },
   
   // Define required styles.
@@ -281,12 +281,21 @@ Module.register('MMM-MyCommute', {
     return(svg);
   },
 
+  formatTimeString: function (time) {
+      var start = moment();
+      var end = start.clone();
+      end = end.add(Number(time), 's');
+      var diff = end.diff(start);
+
+      return moment.utc(diff).format(this.config.travelTimeFormat, {trim: this.config.travelTimeFormatTrim});
+  },
+
   formatTime: function(time, timeInTraffic) {
 
     var timeEl = document.createElement("span");
     timeEl.classList.add("travel-time");
     if (timeInTraffic != null) {
-      timeEl.innerHTML = moment.duration(Number(timeInTraffic), "seconds").format(this.config.travelTimeFormat, {trim: this.config.travelTimeFormatTrim});
+      timeEl.innerHTML = this.formatTimeString(timeInTraffic);
 
       var variance = timeInTraffic / time;
       if (this.config.colorCodeTravelTime) {            
@@ -300,7 +309,7 @@ Module.register('MMM-MyCommute', {
       }
 
     } else {
-      timeEl.innerHTML = moment.duration(Number(time), "seconds").format(this.config.travelTimeFormat, {trim: this.config.travelTimeFormatTrim});
+      timeEl.innerHTML = this.formatTimeString(time);
       timeEl.classList.add("status-good");
     }
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   },
   "homepage": "https://github.com/jclarke0000/MMM-MyCommute#readme",
   "dependencies": {
-    "moment": "^2.18.1",
-    "moment-duration-format": "^1.3.0",
-    "request": "^2.81.0"
+    "moment": "^2.29.4",
+    "request": "^2.88.2"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   }
 }


### PR DESCRIPTION
This PR fixes the `moment.duration(...).format is not a function`.

The new functionality is part of moment.js so we can remove the `moment-duration` and `moment-duration-format` dependencies.

Solves #18 